### PR TITLE
tools/dir2zip: Fix pypi upload of wheel ensuring there is no backslashes

### DIFF
--- a/src/wheeltools/tools.py
+++ b/src/wheeltools/tools.py
@@ -162,7 +162,7 @@ def dir2zip(in_dir, zip_fname):
             in_stat = os.stat(in_fname)
             # Preserve file permissions, but allow copy
             info = zipfile.ZipInfo(in_fname)
-            info.filename = relpath(in_fname, in_dir)
+            info.filename = relpath(in_fname, in_dir).replace("\\", "/")
             # Set time from modification time
             info.date_time = time.localtime(in_stat.st_mtime)
             # See https://stackoverflow.com/questions/434641/how-do-i-set-permissions-


### PR DESCRIPTION
Wheel re-written using dir2zip contained backslashes preventing to
successfully upload the wheel on pypi.

Failure message reported by pypi was:

  HTTPError: 400 Client Error: Invalid distribution file. for url: https://upload.pypi.org/legacy/

Trying to use zip2dir against a wheel that was first re-written using
wheeltools reports the following error:

  warning: wheel_name.whl appears to use backslashes as path separators